### PR TITLE
Remove createJSModules override

### DIFF
--- a/android/src/main/java/org/capslock/RNDeviceBrightness/RNDeviceBrightness.java
+++ b/android/src/main/java/org/capslock/RNDeviceBrightness/RNDeviceBrightness.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 public class RNDeviceBrightness implements ReactPackage {
 
-  @Override
+  // Deprecated in RN 0.47 - facebook/react-native@ce6fb33
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
RN 0.47 introduces a breaking change to createJSModules:
facebook/react-native@ce6fb33

This commit upgrades as advised in the commit message of ce6fb33.
commit a3e180af3155ea7e72395528835a844ba5029622