### PR TITLE
Podspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,31 @@ Run your project (Cmd+R)
 
 (Thanks to @brysgo for writing the instructions)
 
+### iOS (with CocoaPods)
+In your `ios/Podfile` make sure to use `RNDeviceBrightness` from the local
+`node_modules/`. With that, only your project Pod needs to be linked and
+no extra configuration is required:
+
+```ruby
+target 'MyReactApp' do
+  # Make sure you're also using React-Native from ../node_modules
+  pod 'React', :path => '../node_modules/react-native', :subspecs => [
+    'Core',
+    'RCTActionSheet',
+	# ... whatever else you use
+  ]
+  # React-Native dependencies such as yoga:
+  pod 'yoga', path: '../node_modules/react-native/ReactCommon/yoga'
+
+  # The following line uses RNDeviceBrightness, linking with
+  # the library and setting the Header Search Paths for you
+  pod 'RNDeviceBrightness', :path => '../node_modules/react-native-device-brightness'
+end
+```
+
+Remember to run `cd ios && pod install` to update files used by Xcode.
+
+
 ### Android
 
 - in `android/app/build.gradle`:

--- a/RNDeviceBrightness.podspec
+++ b/RNDeviceBrightness.podspec
@@ -1,0 +1,29 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "./package.json")))
+version = package["version"]
+giturl = package["repository"]["url"]
+
+Pod::Spec.new do |s|
+  s.name         = "RNDeviceBrightness"
+  s.version      = version
+  s.summary      = "react-native-device-brightness"
+  s.description  = <<-DESC
+                  Control device screen brightness from React-Native applications
+                   DESC
+  s.homepage     = giturl
+  s.license      = "MIT"
+  # s.license    = { :type => "MIT" }
+  s.author       = { "Calvin Huang" => "calvin.peak@capslock.tw" }
+  s.platform     = :ios, "10.2"
+  s.source       = { :git => giturl + ".git", :tag => version }
+  s.source_files  = "RNDeviceBrightness/*.{h,m}"
+  s.requires_arc = true
+
+
+  s.dependency "React"
+  #s.dependency "others"
+
+end
+
+  


### PR DESCRIPTION
For projects using CocoaPods to manage native dependencies it's useful to include the `RNDeviceBrightness.podspec`.

This PR adds that file and instructions on how to use it.

**NOTE:** do **NOT** send the podspec to cocoapods repo! Users must use the local `../node_modules` path.